### PR TITLE
Allow `omnifocus` to have `version` set

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,18 @@ and ideas into to do lists.
 
 ## Usage
 
+To install the latest 1.x release:
+
 ```puppet
 include omnifocus
+```
+
+or install a specific version:
+
+```puppet
+class { 'omnifocus':
+  version => '2.0.3'
+}
 ```
 
 ## Required Puppet Modules

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -3,9 +3,15 @@
 # Examples
 #
 #   include omnifocus
-class omnifocus {
+#
+# or with specific version
+#
+#   class { 'omnifocus':
+#     version => '2.0.3'
+#   }
+class omnifocus($version = '1.10.4') {
   package { 'OmniFocus':
     provider => 'appdmg_eula',
-    source   => 'http://www.omnigroup.com/ftp1/pub/software/MacOSX/10.6/OmniFocus-1.10.4.dmg'
+    source   => "http://www.omnigroup.com/ftp1/pub/software/MacOSX/10.9/OmniFocus-${version}.dmg"
   }
 }

--- a/spec/classes/omnifocus_spec.rb
+++ b/spec/classes/omnifocus_spec.rb
@@ -1,10 +1,19 @@
 require 'spec_helper'
 
 describe 'omnifocus' do
-  it do
+  it 'Has a default version' do
     should contain_package('OmniFocus').with({
-      :source    => 'http://www.omnigroup.com/ftp1/pub/software/MacOSX/10.6/OmniFocus-1.10.4.dmg',
+      :source    => 'http://www.omnigroup.com/ftp1/pub/software/MacOSX/10.9/OmniFocus-1.10.4.dmg',
       :provider	 => 'appdmg_eula'
     })
+  end
+  context 'with version set' do
+    let(:params) { {:version => '2.0.3'} }
+    it "Supports parameterized versions" do
+      should contain_package('OmniFocus').with({
+        :source    => 'http://www.omnigroup.com/ftp1/pub/software/MacOSX/10.9/OmniFocus-2.0.3.dmg',
+        :provider	 => 'appdmg_eula'
+      })
+    end
   end
 end


### PR DESCRIPTION
I use 2.0, and running my current manifest on a new Mac would give me the previous major version.

This defaults to the current version of `1.10.4` to ensure backwards compatibility. Anyone who wants the current version 2.x should follow the README.
