### PR TITLE
Allow `omnifocus` to have `version` set

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,18 @@ and ideas into to do lists.
 
 ## Usage
 
+To install the latest 2.x release:
+
 ```puppet
 include omnifocus
+```
+
+or install the latest version from the 1.x line:
+
+```puppet
+class { 'omnifocus':
+  version => '1.10.4'
+}
 ```
 
 ## Required Puppet Modules

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,11 +1,17 @@
 # Public: Install OmniFocus to /Applications.
 #
-# Examples
+# Examples:
 #
 #   include omnifocus
-class omnifocus {
+#
+# installs OmniFocus 2; or with specific version:
+#
+#   class { 'omnifocus':
+#     version => '1.10.4'
+#   }
+class omnifocus($version = '2.0.3') {
   package { 'OmniFocus':
     provider => 'appdmg_eula',
-    source   => 'http://www.omnigroup.com/ftp1/pub/software/MacOSX/10.6/OmniFocus-1.10.4.dmg'
+    source   => "http://www.omnigroup.com/ftp1/pub/software/MacOSX/10.9/OmniFocus-${version}.dmg"
   }
 }

--- a/spec/classes/omnifocus_spec.rb
+++ b/spec/classes/omnifocus_spec.rb
@@ -1,10 +1,19 @@
 require 'spec_helper'
 
 describe 'omnifocus' do
-  it do
+  it 'Has a default version of 2+' do
     should contain_package('OmniFocus').with({
-      :source    => 'http://www.omnigroup.com/ftp1/pub/software/MacOSX/10.6/OmniFocus-1.10.4.dmg',
+      :source    => 'http://www.omnigroup.com/ftp1/pub/software/MacOSX/10.9/OmniFocus-2.0.3.dmg',
       :provider	 => 'appdmg_eula'
     })
+  end
+  context 'with version set' do
+    let(:params) { {:version => '1.10.4'} }
+    it "Supports parameterized versions" do
+      should contain_package('OmniFocus').with({
+        :source    => 'http://www.omnigroup.com/ftp1/pub/software/MacOSX/10.9/OmniFocus-1.10.4.dmg',
+        :provider	 => 'appdmg_eula'
+      })
+    end
   end
 end


### PR DESCRIPTION
This defaults to the current version of `2.0.3` - anyone who wants to retain the previous major version should follow the README.

Replaces #1 
